### PR TITLE
armv8/fsl-layerscape: fdt: fixup LS1043A rev1 MSI node with upstream …

### DIFF
--- a/arch/arm/include/asm/arch-fsl-layerscape/soc.h
+++ b/arch/arm/include/asm/arch-fsl-layerscape/soc.h
@@ -53,6 +53,7 @@ struct cpu_type {
 
 #define SVR_MAJ(svr)		(((svr) >> 4) & 0xf)
 #define SVR_MIN(svr)		(((svr) >> 0) & 0xf)
+#define SVR_REV(svr)		(((svr) >> 0) & 0xff)
 #define SVR_SOC_VER(svr)	(((svr) >> 8) & SVR_WO_E)
 #define IS_E_PROCESSOR(svr)	(!((svr >> 8) & 0x1))
 #define IS_SVR_REV(svr, maj, min) \


### PR DESCRIPTION
…method

Revert patch 'armv8/fsl-layerscape: fdt: fixup LS1043A rev1 MSI node'.
Commit id: 5e6f47545e6aaec3e5918b03b3d329b43c4f675c

The patch reverted is sdk version. Then apply the upstream version with
context adjustment and a little change.

Upstream patch: 'armv8/fsl-layerscape: fdt: fixup LS1043A rev1 MSI node'
Commit id: 2ca84bf7b2d7930b424b19f5027d3c06ec7cb696

Signed-off-by: Yangbo Lu <yangbo.lu@nxp.com>